### PR TITLE
Fix import ordering in test_sensor_device

### DIFF
--- a/test_sensor_device.py
+++ b/test_sensor_device.py
@@ -5,13 +5,14 @@ Tests the connected sensor device and provides confirmations for all TODO tasks
 Verifies: DAS capability, storage capacity, USB access, BLE capability, and workflow demo
 """
 
-import serial
 import time
 import json
 import sys
 import subprocess
-import requests
 from datetime import datetime
+
+import serial
+import requests
 
 def test_das_capability_and_storage():
     """Test DAS capability and determine maximum storage - TODO Tasks 1 & 2"""


### PR DESCRIPTION
## Summary
- group built-in imports before third-party imports in `test_sensor_device.py`

## Testing
- `flake8 test_sensor_device.py test_ble_live_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6853ab8491e4832888a872b395d86f22