### PR TITLE
Fix redundant f-string prefixes

### DIFF
--- a/test_sensor_device.py
+++ b/test_sensor_device.py
@@ -37,7 +37,7 @@ def test_das_capability_and_storage():
         # Wait for device to stabilize
         time.sleep(2)
         
-        print(f"📊 Monitoring for DAS initialization and storage info...")
+        print("📊 Monitoring for DAS initialization and storage info...")
         
         start_time = time.time()
         data_logged_count = 0
@@ -266,7 +266,7 @@ def test_ble_capability():
                       capture_output=True, text=True, timeout=5)
         
         if ble_devices:
-            print(f"✅ Found BLE sensor devices:")
+            print("✅ Found BLE sensor devices:")
             for device in ble_devices:
                 print(f"   • {device}")
             ble_service_active = True


### PR DESCRIPTION
## Summary
- remove unnecessary f-string prefixes in `test_sensor_device.py`

## Testing
- `python3 -m py_compile test_sensor_device.py`
- `black --check test_sensor_device.py` *(fails: would reformat)*
- `flake8 test_sensor_device.py` *(fails: command not found)*
- `pylint test_sensor_device.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6853b1920bb08328ba30de3ee58f2c10