### PR TITLE
Clean up rich install logic and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repository contains a small suite of firmware and Python tools for an ESP32-based "Sensor Shield" prototype. The board logs environmental data and exposes it over USB, Wi‑Fi, or BLE.
 
+Before running the scripts, install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Repository Layout
 
 - `Nates Docs.md` – hardware notes and usage tips. Includes wiring tables, storage recommendations, and a typical workflow for retrieving data.

--- a/test_ble_live_data.py
+++ b/test_ble_live_data.py
@@ -571,13 +571,5 @@ Examples:
         return 1
 
 if __name__ == "__main__":
-    # Check dependencies and install if needed
-    try:
-        from rich.console import Console
-    except ImportError:
-        print("Installing Rich library...")
-        subprocess.run([sys.executable, '-m', 'pip', 'install', 'rich', '--break-system-packages'],
-                      capture_output=True)
-
     exit_code = asyncio.run(main())
     sys.exit(exit_code)


### PR DESCRIPTION
## Summary
- remove runtime installation of rich from `test_ble_live_data.py`
- add reminder to `README` to install Python requirements

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_b_68545114d1a08328a1df4c10f61d6ef4