### PR TITLE
Add interactive menu to main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Run it with:
 python3 test_sensor_device.py
 ```
 
+### `main.py`
+
+Run without arguments to get an interactive menu powered by `python-cli-menu`:
+
+```bash
+python3 main.py
+```
+
+All command-line options still work for scripting purposes.
+
 ## Hardware Notes
 
 `Nates Docs.md` provides detailed information on supported storage (MicroSD, SPI flash, I²C EEPROM), wiring guidelines, BLE usage, and troubleshooting tips. It also describes a typical user workflow:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,12 +14,6 @@ bleak>=0.21.0
 # Rich text UI for enhanced terminal output
 rich>=13.7.0
 
-# JSON handling (built-in, no requirement needed)
-# asyncio (built-in, no requirement needed)
-# subprocess (built-in, no requirement needed)
-# time (built-in, no requirement needed)
-# sys (built-in, no requirement needed)  
-# argparse (built-in, no requirement needed)
-# datetime (built-in, no requirement needed)
-# pathlib (built-in, no requirement needed)
-# signal (built-in, no requirement needed) 
+# Interactive CLI menu
+python-cli-menu>=1.8.1
+


### PR DESCRIPTION
## Summary
- add `python-cli-menu` dependency
- integrate interactive arrow-key menu when `main.py` runs without args
- automatically install `python-cli-menu` if needed
- document new interactive mode in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685473e7d86c832888da0108da9a9a5f