### PR TITLE
Add cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements.txt pylint
+      - name: Lint with pylint
+        run: |
+          pylint .
+      - name: Lint with flake8
+        run: |
+          flake8 main.py test.py
+      - name: Run tests
+        run: |
+          pytest -q


### PR DESCRIPTION
## Summary
- enable GitHub Actions on Ubuntu, Windows, and macOS
- run pylint, flake8, and pytest

## Testing
- `pylint main.py test.py tests`
- `flake8 main.py test.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854ab24c7088333a9a70cba2ac3a46e