### PR TITLE
Add multi-OS CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,20 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  test:
+    name: ${{ matrix.name }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            name: Ubuntu
+          - os: macos-latest
+            name: macOS
+          - os: windows-2019
+            name: Windows-10
+          - os: windows-2022
+            name: Windows-11
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -19,6 +28,26 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -r requirements.txt pylint
+      - name: Lint with pylint
+        run: |
+          pylint .
+      - name: Lint with flake8
+        run: |
+          flake8 main.py test.py
+      - name: Run tests
+        run: |
+          pytest -q
+
+  arch:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          pacman -Sy --noconfirm python python-pip git
+          pip install -r requirements.txt pylint
       - name: Lint with pylint
         run: |
           pylint .


### PR DESCRIPTION
## Summary
- run CI on Ubuntu, macOS, Windows 10/11, and Arch

## Testing
- `pylint .`
- `flake8 main.py test.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6854ac256e148333a77a33052cd7020f