### PR TITLE
Fix arch ci pip install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt pylint
+          python -m pip install --break-system-packages -r requirements.txt pylint
       - name: Lint with pylint
         run: |
           pylint .


### PR DESCRIPTION
## Summary
- allow pip install in container-managed Python by using `--break-system-packages` flag

## Testing
- `pylint .`
- `flake8 main.py test.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854aeb2b244833380fbd1bb49a26798