### PR TITLE
Add exhaustive CLI flag tests

### DIFF
--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+import itertools
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 STUBS = ROOT / 'tests' / 'stubs'
@@ -30,47 +32,39 @@ def _assert_output(file_path):
     assert keys <= {'temp', 'humidity', '_timestamp'}
 
 
-def test_serial_cli_all_options(tmp_path):
-    out_file = tmp_path / 'serial.json'
-    result = _run_cli([
-        '-sp',
-        '--dump',
-        '--addr', 'COM1',
-        '-o', str(out_file),
-        '--timeout', '1',
-        '--json',
-        '--filter', 'temp,humidity',
-    ], tmp_path)
-    assert result.returncode == 0
-    _assert_output(out_file)
+DATA_SOURCES = {
+    '-sp': 'COM1',
+    '-wf': '192.168.4.1',
+    '-bt': '00:11:22:33:44:55',
+}
+
+FLAG_COMBINATIONS = list(itertools.product([False, True], repeat=6))
+FLAG_IDS = ["".join('1' if f else '0' for f in combo) for combo in FLAG_COMBINATIONS]
 
 
-def test_wifi_cli_all_options(tmp_path):
-    out_file = tmp_path / 'wifi.json'
-    result = _run_cli([
-        '-wf',
-        '--dump',
-        '--addr', '192.168.4.1',
-        '-o', str(out_file),
-        '--timeout', '1',
-        '--json',
-        '--filter', 'temp,humidity',
-    ], tmp_path)
-    assert result.returncode == 0
-    _assert_output(out_file)
+@pytest.mark.parametrize('source', DATA_SOURCES.keys(), ids=['sp', 'wf', 'bt'])
+@pytest.mark.parametrize('combo', FLAG_COMBINATIONS, ids=FLAG_IDS)
+def test_cli_all_combinations(source, combo, tmp_path):
+    args = [source]
+    out_file = None
+    if combo[0]:
+        args.append('--dump')
+    if combo[1]:
+        args.extend(['--addr', DATA_SOURCES[source]])
+    if combo[2]:
+        out_file = tmp_path / f"{source.strip('-')}_{''.join('1' if b else '0' for b in combo)}.json"
+        args.extend(['-o', str(out_file)])
+    if combo[3]:
+        args.extend(['--timeout', '1'])
+    if combo[4]:
+        args.append('--json')
+    if combo[5]:
+        args.extend(['--filter', 'temp,humidity'])
+
+    result = _run_cli(args, tmp_path)
+    assert result.returncode == 0, f"Failed args {args}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    if out_file:
+        _assert_output(out_file)
 
 
-def test_bluetooth_cli_all_options(tmp_path):
-    out_file = tmp_path / 'ble.json'
-    result = _run_cli([
-        '-bt',
-        '--dump',
-        '--addr', '00:11:22:33:44:55',
-        '-o', str(out_file),
-        '--timeout', '1',
-        '--json',
-        '--filter', 'temp,humidity',
-    ], tmp_path)
-    assert result.returncode == 0
-    _assert_output(out_file)
 


### PR DESCRIPTION
## Summary
- test each combination of CLI flags for every data source

## Testing
- `pylint .`
- `flake8 main.py test.py`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_6854af2075f48333b6730c77fe40ad2d