### PR TITLE
Fix Arch job pip install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: |
           pacman -Sy --noconfirm python python-pip git
-          pip install -r requirements.txt pylint
+          pip install --break-system-packages -r requirements.txt pylint
       - name: Lint with pylint
         run: |
           pylint .


### PR DESCRIPTION
## Summary
- patch CI to add `--break-system-packages` when installing dependencies in Arch job

## Testing
- `pylint .`
- `flake8 main.py test.py`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_b_6854b4ca074883338fe0a29458f8b9ad