### PR TITLE
Fix lint warnings and None check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -302,7 +302,8 @@ max-bool-expr=5
 max-branches=12
 
 # McCabe complexity threshold (turn on the mccabe checker)
-max-complexity=10
+# max-complexity is not recognized by the installed pylint version
+# so it has been disabled
 
 # Maximum number of locals for function / method body.
 max-locals=15

--- a/test.py
+++ b/test.py
@@ -330,20 +330,18 @@ def test_ble_capability():
 
     try:
         # Try to scan for BLE devices
-        result = subprocess.run(
+        subprocess.run(
             ["bluetoothctl", "scan", "on"], capture_output=True, text=True, timeout=5
         )
 
         time.sleep(3)  # Allow time for scan
 
-        result = subprocess.run(
+        devices_result = subprocess.run(
             ["bluetoothctl", "devices"], capture_output=True, text=True, timeout=5
         )
 
-        if result.stdout:
-            devices = result.stdout.splitlines()
-        else:
-            devices = []
+        devices_output = devices_result.stdout or ""
+        devices = devices_output.splitlines()
         ble_devices = [
             d
             for d in devices


### PR DESCRIPTION
## Summary
- avoid unsupported `max-complexity` option in `.pylintrc`
- guard against missing stdout when scanning for BLE devices

## Testing
- `pylint .`
- `flake8 main.py test.py`
- `pytest -v` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_6854bd76f1b883289696ab358ff1101e