### PR TITLE
Fix test.py lint issues and update pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -302,7 +302,6 @@ max-bool-expr=5
 max-branches=12
 
 # McCabe complexity threshold (turn on the mccabe checker)
-max-complexity=10
 
 # Maximum number of locals for function / method body.
 max-locals=15

--- a/test.py
+++ b/test.py
@@ -340,10 +340,7 @@ def test_ble_capability():
             ["bluetoothctl", "devices"], capture_output=True, text=True, timeout=5
         )
 
-        if result.stdout:
-            devices = result.stdout.splitlines()
-        else:
-            devices = []
+        devices = result.stdout.splitlines() if result.stdout else []
         ble_devices = [
             d
             for d in devices


### PR DESCRIPTION
## Summary
- handle potential missing stdout from `bluetoothctl` results
- drop unsupported `max-complexity` option from `.pylintrc`

## Testing
- `flake8 main.py test.py`
- `pylint .`
- `pytest -v` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_6854bca5382483339c2040f56413c21a