### PR TITLE
Fix serial stub live mode

### DIFF
--- a/tests/stubs/serial.py
+++ b/tests/stubs/serial.py
@@ -1,5 +1,18 @@
 class Serial:
+    """Simple stub of ``pyserial.Serial`` supporting dump and live modes."""
+
     def __init__(self, *_, **__):
+        self._index = 0
+        self._set_live_data()
+
+    def _set_live_data(self):
+        self._data = (
+            b"Booting...\n"
+            b"Data logged: {\"temp\":25,\"humidity\":60}\n"
+            b"Data logged: {\"temp\":26,\"humidity\":61}\n"
+        )
+
+    def _set_dump_data(self):
         self._data = b"DUMP_START\n{\"temp\":25,\"humidity\":60}\nDUMP_END\n"
         self._index = 0
 
@@ -7,20 +20,24 @@ class Serial:
     def in_waiting(self):
         return len(self._data) - self._index
 
-    def write(self, _):
-        pass
+    def write(self, data):
+        if b"DUMP_ALL" in data:
+            self._set_dump_data()
 
     def read(self, size=1):
         start = self._index
         end = min(start + size, len(self._data))
+        chunk = self._data[start:end]
         self._index = end
-        return self._data[start:end]
+        return chunk
 
     def readline(self):
         newline = self._data.find(b"\n", self._index)
         if newline == -1:
             newline = len(self._data)
-        end = newline + 1
+            end = newline
+        else:
+            end = newline + 1
         chunk = self._data[self._index:end]
         self._index = end
         return chunk
@@ -30,3 +47,4 @@ class Serial:
 
 class SerialException(Exception):
     pass
+


### PR DESCRIPTION
## Summary
- improve serial stub to emit live data when used without `--dump`

## Testing
- `pylint .`
- `flake8 main.py test.py`
- `pytest tests/test_main_cli.py::test_cli_all_combinations[001000-sp] -v`

------
https://chatgpt.com/codex/tasks/task_b_6854bc8aa5008333bf0ddcaa878966ba