### PR TITLE
Fix pylint issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -302,7 +302,10 @@ max-bool-expr=5
 max-branches=12
 
 # McCabe complexity threshold (turn on the mccabe checker)
-max-complexity=10
+# Disable the McCabe complexity threshold since the mccabe extension is not
+# enabled in some environments, which causes an "unrecognized option" error
+# when parsing this configuration.
+# max-complexity=10
 
 # Maximum number of locals for function / method body.
 max-locals=15

--- a/main.py
+++ b/main.py
@@ -650,7 +650,10 @@ Examples:
         raise RuntimeError("Argument parsing failed")
 
     # Launch interactive menu if no mode provided
-    if args is not None and not any([args.serial_port, args.wifi, args.bluetooth]):
+    # argparse always returns a Namespace instance so args will never be None
+    # Directly check the selected mode flags to decide if the interactive menu
+    # should be shown.
+    if not any([args.serial_port, args.wifi, args.bluetooth]):
         if not MENU_AVAILABLE:
             raise RuntimeError(
                 "Interactive menu requested but InquirerPy is not installed."
@@ -726,7 +729,10 @@ Examples:
         out_file = out_resp.strip() if out_resp else None
         if out_file:
             args.output = out_file
-        default_timeout = args.timeout if args else 30
+        # ``args`` is guaranteed to be a Namespace object so ``args.timeout``
+        # will always be available. The check for ``args`` is therefore
+        # unnecessary and confuses static analyzers.
+        default_timeout = args.timeout
         timeout_resp = (
             inquirer.text(
                 message=f"Timeout in seconds (default {default_timeout}): ",

--- a/test.py
+++ b/test.py
@@ -340,7 +340,9 @@ def test_ble_capability():
             ["bluetoothctl", "devices"], capture_output=True, text=True, timeout=5
         )
 
-        if result.stdout:
+        # ``result.stdout`` is of type ``Optional[str]``. Explicitly handle the
+        # ``None`` case to avoid ``no-member`` lint errors.
+        if result.stdout is not None:
             devices = result.stdout.splitlines()
         else:
             devices = []


### PR DESCRIPTION
## Summary
- handle optional argparse Namespace without confusing pylint
- avoid attribute error on `splitlines` in tests
- comment out `max-complexity` in `.pylintrc` to prevent config error

## Testing
- `flake8 main.py test.py`
- `pylint .`
- `pytest -v` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_6854bcb59f3c833388815a3d518e5d3f