### PR TITLE
Fix BLE device scanning list creation

### DIFF
--- a/test.py
+++ b/test.py
@@ -341,7 +341,7 @@ def test_ble_capability():
         )
 
         if result.stdout:
-            devices = result.stdout.strip().split("\n")
+            devices = result.stdout.splitlines()
         else:
             devices = []
         ble_devices = [


### PR DESCRIPTION
## Summary
- avoid calling `.strip()` on `None` when parsing BLE scan results

## Testing
- `pylint .`
- `flake8 main.py test.py`
- `pytest -v` *(fails: timed out after 30s)*

------
https://chatgpt.com/codex/tasks/task_b_6854b8a4e7ac8333a79dafa8b76c8ccd